### PR TITLE
Fix l'erreur de supression de la date de  paiement sur  l'accompte

### DIFF
--- a/Lymytz_Web/src/java/yvs/base/compta/UtilCompta.java
+++ b/Lymytz_Web/src/java/yvs/base/compta/UtilCompta.java
@@ -1866,7 +1866,7 @@ public class UtilCompta {
             r.setNotifs(y.getNotifs());
             r.setDateSave(y.getDateSave());
             r.setPhasesReglement(y.getPhasesReglement());
-
+            r.setDatePaiement(y.getDatePaiement());
             for (YvsComptaNotifReglementAchat c : y.getNotifs()) {
                 r.getAchatDiverses().add(buildBeanAcomptesAchatDivers(c));
             }
@@ -1902,6 +1902,7 @@ public class UtilCompta {
             r.setNew_(true);
             r.setDateSave(y.getDateSave());
             r.setReferenceExterne(y.getReferenceExterne());
+            r.setDatePaiement(y.getStatut()!=Constantes.STATUT_DOC_PAYER? null:y.getDatePaiement());
             r.setDateUpdate(new Date());
         }
         return r;

--- a/Lymytz_Web/src/java/yvs/comptabilite/fournisseur/AcompteFournisseur.java
+++ b/Lymytz_Web/src/java/yvs/comptabilite/fournisseur/AcompteFournisseur.java
@@ -48,6 +48,7 @@ public class AcompteFournisseur implements Serializable {
     private String firstEtape = "VALIDER";
     private List<YvsComptaNotifReglementDocDivers> notifs_doc;
     private List<AcomptesAchatDivers> achatDiverses;
+    private Date datePaiement;
     
 
     public AcompteFournisseur() {
@@ -229,6 +230,31 @@ public class AcompteFournisseur implements Serializable {
         this.firstEtape = firstEtape;
     }
 
+    public List<YvsComptaNotifReglementDocDivers> getNotifs_doc() {
+        return notifs_doc;
+    }
+
+    public void setNotifs_doc(List<YvsComptaNotifReglementDocDivers> notifs_doc) {
+        this.notifs_doc = notifs_doc;
+    }
+
+    public List<AcomptesAchatDivers> getAchatDiverses() {
+        return achatDiverses;
+    }
+
+    public void setAchatDiverses(List<AcomptesAchatDivers> achatDiverses) {
+        this.achatDiverses = achatDiverses;
+    }
+    
+    public void setDatePaiement(Date datePaiement) {
+        this.datePaiement = datePaiement;
+    }
+
+    public Date getDatePaiement() {
+        return datePaiement;
+    }
+
+
     @Override
     public int hashCode() {
         int hash = 7;
@@ -250,25 +276,6 @@ public class AcompteFournisseur implements Serializable {
         }
         return true;
     }
-
-    public List<YvsComptaNotifReglementDocDivers> getNotifs_doc() {
-        return notifs_doc;
-    }
-
-    public void setNotifs_doc(List<YvsComptaNotifReglementDocDivers> notifs_doc) {
-        this.notifs_doc = notifs_doc;
-    }
-
-    public List<AcomptesAchatDivers> getAchatDiverses() {
-        return achatDiverses;
-    }
-
-    public void setAchatDiverses(List<AcomptesAchatDivers> achatDiverses) {
-        this.achatDiverses = achatDiverses;
-    }
-    
-    
-    
     
 
 }

--- a/Lymytz_Web/src/java/yvs/comptabilite/fournisseur/ManagedOperationFournisseur.java
+++ b/Lymytz_Web/src/java/yvs/comptabilite/fournisseur/ManagedOperationFournisseur.java
@@ -938,7 +938,7 @@ public class ManagedOperationFournisseur extends Managed<AcompteFournisseur, Yvs
                 if (bean.getId() > 0) {
                     dao.update(selectCompte);
                 } else {
-                    selectCompte.setId(null);
+                    selectCompte.setId(null);                    
                     selectCompte = (YvsComptaAcompteFournisseur) dao.save1(selectCompte);
                     bean.setId(selectCompte.getId());
                     bean.setReste(bean.getMontant());

--- a/Lymytz_Web/src/java/yvs/util/Managed.java
+++ b/Lymytz_Web/src/java/yvs/util/Managed.java
@@ -882,7 +882,7 @@ public abstract class Managed<T extends Serializable, S extends Serializable> im
     }
 
     /**
-     * copie les propriétés de l'objet o dans l'objet o
+     * copie les propriétés de l'objet source dans l'objet cible sans en changer la référence
      *
      * @param cible
      * @param source
@@ -901,7 +901,6 @@ public abstract class Managed<T extends Serializable, S extends Serializable> im
                     lf0[i].set(cible, f.get(source));
                     i++;
                 } catch (IllegalArgumentException | IllegalAccessException ex) {
-                    System.err.println("Name : " + f.getName());
                     Logger.getLogger(Managed.class.getName()).log(Level.SEVERE, null, ex);
                 }
             }


### PR DESCRIPTION
L'lorsqu'on modifiais la nature d'un acompte fournisseur déjà payé, la date de paiement étais perdu