### PR TITLE
Associer YvsHistoriquePr à YvsBaseConditionnement et à YvsBaseDepots

### DIFF
--- a/Lymytz_Ejb/src/java/yvs/entity/commercial/YvsHistoriquePr.java
+++ b/Lymytz_Ejb/src/java/yvs/entity/commercial/YvsHistoriquePr.java
@@ -10,9 +10,12 @@ import java.util.Date;
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.SequenceGenerator;
@@ -21,6 +24,8 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.persistence.Transient;
 import javax.xml.bind.annotation.XmlRootElement;
+import yvs.entity.base.YvsBaseConditionnement;
+import yvs.entity.base.YvsBaseDepots;
 
 /**
  *
@@ -46,10 +51,12 @@ public class YvsHistoriquePr implements Serializable {
     private Date dateEvaluation;
     @Column(name = "pr")
     private Double pr;
-    @Column(name = "conditionnement")
-    private Long conditionnement;
-    @Column(name = "depot")
-    private Long depot;
+    @JoinColumn(name = "conditionnement", referencedColumnName = "id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private YvsBaseConditionnement conditionnement;
+    @JoinColumn(name = "depot", referencedColumnName = "id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private YvsBaseDepots depot;
     @Transient
     private boolean select;
 
@@ -84,19 +91,19 @@ public class YvsHistoriquePr implements Serializable {
         this.pr = pr;
     }
 
-    public Long getConditionnement() {
-        return conditionnement != null ? conditionnement : 0;
+    public YvsBaseConditionnement getConditionnement() {
+        return conditionnement;
     }
 
-    public void setConditionnement(Long conditionnement) {
+    public void setConditionnement(YvsBaseConditionnement conditionnement) {
         this.conditionnement = conditionnement;
     }
 
-    public Long getDepot() {
-        return depot != null ? depot : 0;
+    public YvsBaseDepots getDepot() {
+        return depot;
     }
 
-    public void setDepot(Long depot) {
+    public void setDepot(YvsBaseDepots depot) {
         this.depot = depot;
     }
 

--- a/Lymytz_Web/web/pages/gescom/other/yvs_historique_pr.xhtml
+++ b/Lymytz_Web/web/pages/gescom/other/yvs_historique_pr.xhtml
@@ -11,7 +11,7 @@
         #{navigations.naviguationApps('Historique PR','modGescom', 'smenHistoriquePR', true, managedHistoriquePR)}
     </ui:define> 
     <ui:define name="contents">
-        #{managedHistoriquePR.doNothing()}
+        #{managedHistoriquePR.choosePrSearch()}
         #{managedDepot.loadAllDepot()}
         <script type="text/javascript">
             $(function() {
@@ -56,13 +56,13 @@
                                 <span>#{hist.id}</span>
                             </p:column>
                             <p:column headerText="Article">
-                                <span>#{managedHistoriquePR.getArticleName(hist)}</span>
+                                <span>#{hist.conditionnement.article.designation} [#{hist.conditionnement.unite.reference}]</span>
                             </p:column>
                             <p:column headerText="Date evaluation" style="text-align: center;width: 20%">
                                 <h:outputText value="#{hist.dateEvaluation}" converter="DATE"/>
                             </p:column>
                             <p:column headerText="#{lab.LC_PCP_depot}">
-                                <span>#{managedHistoriquePR.getDepotName(hist)}</span> 
+                                <span>#{hist.depot.designation}</span> 
                             </p:column>
                             <p:column headerText="P.R" style="text-align: right;width: 20%">
                                 <h:outputText value="#{hist.pr}" converter="DNA"/>
@@ -127,34 +127,43 @@
                 <div class="yvs_form_historique_pr display_auteur" align="right"  style="font-style: italic;">
 
                 </div>
-                <h:panelGrid columns="3" style="float: left; font-size: 0.8em" cellpadding="0" cellspacing="0">
-                    <h:outputText value="Date" />
-                    <h:outputText value="Article" />
-                    <h:outputText value="Depot" />
-                    <h:panelGrid columns="2" style="font-size: 0.8em;margin-top: 3px" styleClass="yvs_nostyle" cellpadding="0" cellspacing="0">
-                        <h:selectBooleanCheckbox value="#{managedHistoriquePR.dateSearch}" style="margin-top: 2px;float: right">
+                <h:panelGrid columns="4" style="float: left; font-size: 0.8em" cellpadding="0" cellspacing="0">
+                    <h:panelGroup>
+                        <h:selectBooleanCheckbox value="#{managedHistoriquePR.dateSearch}">
                             <p:ajax event="valueChange" listener="#{managedHistoriquePR.chooseDateSearch()}" update="blog_date_search_historique_pr :main_historique_pr:data_historique_pr"/>
                         </h:selectBooleanCheckbox>
-                        <h:panelGrid columns="2" style="float: right;margin-top: 3px">
-                            <h:panelGroup id="blog_date_search_historique_pr">
-                                <p:calendar value="#{managedHistoriquePR.dateDebutSearch}" navigator="true" pattern="dd-MM-yyyy" disabled="#{!managedHistoriquePR.dateSearch}" size="10" style="font-size: 0.8em">
-                                    <p:ajax event="dateSelect" listener="#{managedHistoriquePR.chooseDateSearch()}" update=":main_historique_pr:data_historique_pr"/>
-                                </p:calendar>
-                                <p:spacer width="5px" style="background: black"/>
-                                <p:calendar value="#{managedHistoriquePR.dateFinSearch}" navigator="true" pattern="dd-MM-yyyy" disabled="#{!managedHistoriquePR.dateSearch}" size="10" style="font-size: 0.8em">
-                                    <p:ajax event="dateSelect" listener="#{managedHistoriquePR.chooseDateSearch()}" update=":main_historique_pr:data_historique_pr"/>
-                                </p:calendar>
-                            </h:panelGroup>
-                        </h:panelGrid>
-                    </h:panelGrid>
+                        <h:outputText value="Date" />
+                    </h:panelGroup>
+                    <h:outputText value="Article" />
+                    <h:outputText value="Depot" />
+                    <h:panelGroup>
+                        <h:outputText value="PR" style="float:left;margin-top: 2px"/>
+                        <h:selectOneMenu value="#{managedHistoriquePR.operateurPrSearch}" style="float:right;margin-right: 5px;">
+                            <f:selectItem itemLabel="#{lab.LC_PRA_egale}" itemValue="="/>
+                            <f:selectItem itemLabel="Supérieur" itemValue=">"/>
+                            <p:ajax event="valueChange" update=":main_historique_pr:data_historique_pr" listener="#{managedHistoriquePR.choosePrSearch()}" />
+                        </h:selectOneMenu>  
+                    </h:panelGroup>
+                    <h:panelGroup id="blog_date_search_historique_pr">
+                        <p:calendar value="#{managedHistoriquePR.dateDebutSearch}" navigator="true" pattern="dd-MM-yyyy" disabled="#{!managedHistoriquePR.dateSearch}" size="10" style="font-size: 0.9em">
+                            <p:ajax event="dateSelect" listener="#{managedHistoriquePR.chooseDateSearch()}" update=":main_historique_pr:data_historique_pr"/>
+                        </p:calendar>
+                        <p:spacer width="5px" style="background: black"/>
+                        <p:calendar value="#{managedHistoriquePR.dateFinSearch}" navigator="true" pattern="dd-MM-yyyy" disabled="#{!managedHistoriquePR.dateSearch}" size="10" style="font-size: 0.9em">
+                            <p:ajax event="dateSelect" listener="#{managedHistoriquePR.chooseDateSearch()}" update=":main_historique_pr:data_historique_pr"/>
+                        </p:calendar>
+                    </h:panelGroup>
                     <h:inputText value="#{managedHistoriquePR.articleSearch}">
                         <p:ajax event="blur" listener="#{managedHistoriquePR.searchArticle()}" update=":main_historique_pr:data_historique_pr"/>
                     </h:inputText>
                     <h:selectOneMenu value="#{managedHistoriquePR.depotSearch}" id="_select_depot_historique_pr" style="width: 100%">
                         <f:selectItem itemLabel="" itemValue="0"/>
                         <f:selectItems value="#{managedDepot.depots_all}" var="de" itemLabel="#{de.designation}" itemValue="#{de.id}"/>
-                        <p:ajax event="valueChange" listener="#{managedHistoriquePR.chooseDepotSeach()}" update=":main_historique_pr:data_historique_pr"/>
+                        <p:ajax event="valueChange" listener="#{managedHistoriquePR.chooseDepotSearch()}" update=":main_historique_pr:data_historique_pr"/>
                     </h:selectOneMenu>
+                    <h:inputText value="#{managedHistoriquePR.prSearch}" style="width: 120px">
+                        <p:ajax event="blur" listener="#{managedHistoriquePR.choosePrSearch()}" update=":main_historique_pr:data_historique_pr"/>
+                    </h:inputText>
                 </h:panelGrid>
             </div>
         </h:form>

--- a/Lymytz_Web/web/pages/gescom/other/yvs_historique_pr.xhtml
+++ b/Lymytz_Web/web/pages/gescom/other/yvs_historique_pr.xhtml
@@ -52,9 +52,6 @@
                             <p:column headerText="N°" style="text-align: center;width: 25px">
                                 <span>#{histIdx+1}</span>
                             </p:column>
-                            <p:column headerText="ID" style="text-align: center;width: 10%">
-                                <span>#{hist.id}</span>
-                            </p:column>
                             <p:column headerText="Article">
                                 <span>#{hist.conditionnement.article.designation} [#{hist.conditionnement.unite.reference}]</span>
                             </p:column>


### PR DESCRIPTION
…et  YvsBaseDepots

- Modification de l'entité YvsHistoriquePr pour associer les entités YvsBaseConditionnement  et YvsBaseDepots
- Adaptation de la page yvs_historique.xhtml pour afficher les valeurs des entités associées
- Ajouter un filtrer sur le PR
- filtrer les valeurs sur le PR > 0 aux chargement des données